### PR TITLE
Using v1 apis for CRD/Webhook

### DIFF
--- a/config/300-prometheussource.yaml
+++ b/config/300-prometheussource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -29,6 +29,34 @@ metadata:
   name: prometheussources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+    - &version
+      name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flesh out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+        - name: Sink
+          type: string
+          jsonPath: .status.sinkUri
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   names:
     categories:
     - all
@@ -38,131 +66,3 @@ spec:
     kind: PrometheusSource
     plural: prometheussources
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            serviceAccountName:
-              type: string
-              description: >
-                ServiceAccountName holds the name of the Kubernetes service account
-                as which the Prometheus source should run. If unspecified
-                this will default to the "default" service account for the namespace
-                in which the PrometheusSource exists
-            serverURL:
-              type: string
-              description:
-                URL of the Prometheus server to run queries against
-            promQL:
-              type: string
-              description: >
-                The PromQL query to run against the Prometheus server. This is a range query if
-                the step property is specified and an instant query otherwise. For a range query,
-                the start time is the previous time the query ran and the end time is now, with
-                the step property specifying the resolution step.
-            authTokenFile:
-              type: string
-              description:
-                The name of the file containing the authenication token
-            caCertConfigMap:
-              type: string
-              description: >
-                The name of the config map containing the CA certificate of the
-                Prometheus service's signer
-            schedule:
-              type: string
-              description:
-                A crontab-formatted schedule for running the PromQL query
-            step:
-              type: string
-              description: >
-                Query resolution step width in duration format or float number of seconds.
-                Prometheus duration strings are of the form [0-9]+[smhdwy]. For example,
-                5m refers to a duration of 5 minutes. This is an optional property that if
-                specified, implies that promQL is a range query. Otherwise, promQL is interpreted
-                as an instant query.
-            sink:
-              anyOf:
-              - type: object
-                description: "The destination that should receive events"
-                properties:
-                  ref:
-                    type: object
-                    description: "The reference to a Kubernetes object from which to retrieve the target URI"
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                    properties:
-                      apiVersion:
-                        type: string
-                        minLength: 1
-                      kind:
-                        type: string
-                        minLength: 1
-                      name:
-                        type: string
-                        minLength: 1
-                  uri:
-                    type: string
-                    description: "The target URI. If ref is provided, this must be a relative URI reference"
-              - type: object
-                description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
-                required:
-                - apiVersion
-                - kind
-                - name
-                properties:
-                  apiVersion:
-                    type: string
-                    minLength: 1
-                  kind:
-                    type: string
-                    minLength: 1
-                  name:
-                    type: string
-                    minLength: 1
-                  uri:
-                    type: string
-                    description: "the target URI. If ref is provided, this must be relative URI reference."
-          required:
-              - serverURL
-              - promQL
-              - schedule
-              - sink
-          type: object
-        status:
-          properties:
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  severity:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - type
-                - status
-                type: object
-              type: array
-            sinkUri:
-              type: string
-          type: object
-  version: v1alpha1

--- a/config/500-webhook-config.yaml
+++ b/config/500-webhook-config.yaml
@@ -12,34 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.prometheus.sources.knative.dev
   labels:
     contrib.eventing.knative.dev/release: devel
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: prometheus-source-webhook
         namespace: knative-sources
+    sideEffects: None
     failurePolicy: Fail
     name: defaulting.webhook.prometheus.sources.knative.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.prometheus.sources.knative.dev
   labels:
     contrib.eventing.knative.dev/release: devel
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: prometheus-source-webhook
         namespace: knative-sources
+    sideEffects: None
     failurePolicy: Fail
     name: validation.webhook.prometheus.sources.knative.dev


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- updating to v1 APIs for `CRD` and `Webhooks`
- removed some of the bogus openAPI (can be adjusted in different PR)
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Using Kube v1 APIs for CRD/Webhook
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
